### PR TITLE
gw: mars.c: fix fake comet name

### DIFF
--- a/pkg/vere/mars.c
+++ b/pkg/vere/mars.c
@@ -1707,7 +1707,12 @@ _mars_boot_make(u3_boot_opts* inp_u,
 
       case c3__fake: {
         met_u->fak_o = c3y;
-        who          = dat;
+        if ( c3y == u3a_is_atom(dat) ) {
+          who = dat;
+        }
+        else {
+          who = u3h(u3t(u3t(dat)));
+        }
       } break;
 
       case c3__dawn: {


### PR DESCRIPTION
fix an issue deriving the ship name for fake comets in mars.c that must've got introduced from upstream at some point