### PR TITLE
ames: null guard in ames_pact_free

### DIFF
--- a/pkg/vere/io/ames/ames.c
+++ b/pkg/vere/io/ames/ames.c
@@ -264,7 +264,9 @@ _ames_pact_free(u3_pact* pac_u)
       exit(1);
   }
 
-  _ames_ref_hun_lose(pac_u->hun_u);
+  if ( pac_u->hun_u ) {
+    _ames_ref_hun_lose(pac_u->hun_u);
+  }
   c3_free(pac_u);
 }
 


### PR DESCRIPTION
Fixes a bug unique to Groundwire's Vere where attempting to `|hi` an Azimuth ship on 408k would crash our ship and render us unable to run without the `-L` flag.