### PR TITLE
ames: fix Ames send path to ignore zero lanes and initialize scry lane buffer

### DIFF
--- a/pkg/vere/io/ames/ames.c
+++ b/pkg/vere/io/ames/ames.c
@@ -1278,7 +1278,7 @@ _ames_send_many(u3_pact* pac_u, sockaddr_in lan_u[2], c3_o for_o)
   }
 
   for ( c3_w i = 0;
-        ( (i < 2) && _mesa_is_lane_zero(lan_u[i]) );
+        ( (i < 2) && (c3n == _mesa_is_lane_zero(lan_u[i])) );
         i++) {
     _ames_send(sam_u, lan_u[i], _ames_ref_hun_gain(pac_u->hun_u));
   }
@@ -1308,7 +1308,7 @@ _ames_lane_scry_cb(u3_pact* pac_u, u3_peer* per_u)
   }
   else {
     sam_u->sat_u.saw_d = 0;
-    sockaddr_in lan_u[2];
+    sockaddr_in lan_u[2] = {0};
     _ames_lane_from_peer(sam_u, per_u, lan_u);
     
     //  if there are lanes, send the packet on them; otherwise drop it


### PR DESCRIPTION
## Summary

Fix two issues in the Ames outbound send path that could cause sends to use garbage lane data.

- Only send on nonzero lanes in _ames_send_many()
- Zero-initialize the local sockaddr_in lan_u[2] buffer in _ames_lane_scry_cb()

## Why

_ames_lane_scry_cb() asks _ames_lane_from_peer() to populate a local two-lane buffer. That callee does not guarantee every slot is written on every successful return path, so the local buffer must be initialized before use.

Separately, _ames_send_many() was iterating while _mesa_is_lane_zero(lan_u[i]) was true, which is the opposite of the intended behavior. That allowed the send path to operate on invalid lane entries.

Together, these issues could surface as outbound sends using malformed sockaddr_in data.

## Result

The send path now only uses valid nonzero lanes, and the scry callback no longer risks reading uninitialized lane entries.