### PR TITLE
build: use git rev-parse instead of HEAD file

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -204,21 +204,12 @@ pub fn build(b: *std.Build) !void {
     const tracy_callstack = b.option(bool, "tracy-callstack", "Enable Tracy callstack capture") orelse false;
     const tracy_no_exit = b.option(bool, "tracy-no-exit", "Wait for profiler connection before exiting") orelse false;
 
-    // Parse short git rev
-    var file = try std.fs.cwd().openFile(".git/logs/HEAD", .{});
-    defer file.close();
-    var buf: [4096]u8 = undefined;
-    var reader = file.reader(&buf);
-    var last_line: [4096]u8 = undefined;
-    while (reader.interface.takeDelimiterInclusive('\n')) |line| {
-        if (line.len > 0)
-            last_line = buf;
-    } else |err| if (err != error.EndOfStream) return err;
-    const git_rev = buf[41..48];
+    const git_rev_cmd = b.run(&.{ "git", "rev-parse", "--short=7", "HEAD" });
+    const git_rev = std.mem.trim(u8, git_rev_cmd, &std.ascii.whitespace);
 
     // Binary version
     const version = if (!release)
-        VERSION ++ "-" ++ git_rev
+        b.fmt("{s}-{s}", .{ VERSION, git_rev })
     else
         VERSION;
 


### PR DESCRIPTION
Fixed issue where `.git/logs/HEAD` was not being parsed correctly, which caused Zig to build with stale files from its cache. This is one of several build issues observed on newer macOS Tahoe versions (in this case 26.3.1) and may be platform-specific, but seems like a sensible change in any case.